### PR TITLE
Fix compilation error on C++17 or later

### DIFF
--- a/Statistic.h
+++ b/Statistic.h
@@ -72,11 +72,13 @@ namespace std {
 
 #if HAVE_STDCXX_CMATH || defined(_GLIBCXX_CMATH)
 #include <cmath>
+#if not defined(__cplusplus) || __cplusplus < 201703L
 //  substitute for std::sqrtf function, patch for issue #13
 #undef sqrtf
 namespace std {
   inline float sqrtf(float n) { return __builtin_sqrtf(n); }
 };
+#endif
 #else
 #include <math.h>
 //  substitute for std::sqrt functions if not in your tool chain


### PR DESCRIPTION
There is a compilation error on C++17 or later.

```
In file included from test.cpp:1:
Statistic.h:79:29: error: 'float std::sqrtf(float)' conflicts with a previous declaration
   79 |   inline float sqrtf(float n) { return __builtin_sqrtf(n); }
      |                             ^
In file included from /usr/include/c++/14/cmath:47,
                 from Statistic.h:74:
/usr/include/bits/mathcalls.h:143:1: note: previous declaration 'float sqrtf(float)'
  143 | __MATHCALL (sqrt,, (_Mdouble_ __x));
      | ^~~~~~~~~~
```
I met this problem on gcc 14.2.1 with `-std=c++17`.

This PR tries to fix this.
